### PR TITLE
Wrapper update

### DIFF
--- a/pettingzoo/classic/chess/chess_env.py
+++ b/pettingzoo/classic/chess/chess_env.py
@@ -37,7 +37,7 @@ class raw_env(AECEnv):
 
         self.rewards = None
         self.dones = None
-        self.infos = None
+        self.infos = {name: {} for name in self.agents}
 
         self.agent_selection = None
 

--- a/pettingzoo/utils/wrappers.py
+++ b/pettingzoo/utils/wrappers.py
@@ -31,7 +31,12 @@ class BaseWrapper(AECEnv):
 
         # self.rewards = self.env.rewards
         # self.dones = self.env.dones
-        self.infos = self.env.infos
+
+        # we don't want to care one way or the other whether environments have an infos or not before reset
+        try:
+            self.infos = self.env.infos
+        except AttributeError:
+            pass
 
         # self.agent_order = self.env.agent_order
 

--- a/pettingzoo/utils/wrappers.py
+++ b/pettingzoo/utils/wrappers.py
@@ -178,7 +178,7 @@ class OrderEnforcingWrapper(BaseWrapper):
     '''
     check all orders:
 
-    * error on getting rewards, dones, agent_selection, agent_order before reset
+    * error on getting rewards, dones, infos, agent_selection, agent_order before reset
     * error on calling step, observe before reset
     * warn on calling close before render or reset
     * warn on calling step after environment is done
@@ -193,7 +193,7 @@ class OrderEnforcingWrapper(BaseWrapper):
         raises an error message when data is gotten from the env
         which should only be gotten after reset
         '''
-        if value in {"rewards", "dones", "agent_selection", "agent_order"}:
+        if value in {"rewards", "dones", "infos", "agent_selection", "agent_order"}:
             EnvLogger.error_field_before_reset(value)
             return None
         else:


### PR DESCRIPTION
Is this the right way to handle things?

* If done is true when an agent is stepped, step just returns the observation of the agent, and sets rewards to zero, does not call parent's step
* Infos can be set or not set at beginning of the environment, the wrapper does not care