### PR TITLE
upgraded rlcard to 0.2.1 and made the environments seed correctly

### DIFF
--- a/pettingzoo/classic/dou_dizhu/dou_dizhu.py
+++ b/pettingzoo/classic/dou_dizhu/dou_dizhu.py
@@ -8,8 +8,8 @@ import numpy as np
 from pettingzoo.utils import wrappers
 
 
-def env():
-    env = raw_env()
+def env(**kwargs):
+    env = raw_env(**kwargs)
     env = wrappers.TerminateIllegalWrapper(env, illegal_reward=-1)
     env = wrappers.AssertOutOfBoundsWrapper(env)
     env = wrappers.NaNRandomWrapper(env)
@@ -21,12 +21,9 @@ class raw_env(AECEnv):
 
     metadata = {'render.modes': ['human']}
 
-    def __init__(self, seed=None, **kwargs):
+    def __init__(self, seed=None):
         super().__init__()
-        if seed is not None:
-            np.random.seed(seed)
-            random.seed(seed)
-        self.env = rlcard.make('doudizhu', **kwargs)
+        self.env = rlcard.make('doudizhu', config={"seed": seed})
         self.agents = ['landlord_0', 'peasant_0', 'peasant_1']
         self.num_agents = len(self.agents)
         self.has_reset = False
@@ -93,7 +90,7 @@ class raw_env(AECEnv):
 
     def reset(self, observe=True):
         self.has_reset = True
-        obs, player_id = self.env.init_game()
+        obs, player_id = self.env.reset()
         self.agent_selection = self._agent_selector.reset()
         self.rewards = self._convert_to_dict(np.array([0.0, 0.0, 0.0]))
         self.dones = self._convert_to_dict([False for _ in range(self.num_agents)])

--- a/pettingzoo/classic/gin_rummy/gin_rummy.py
+++ b/pettingzoo/classic/gin_rummy/gin_rummy.py
@@ -13,8 +13,8 @@ import numpy as np
 from pettingzoo.utils import wrappers
 
 
-def env():
-    env = raw_env()
+def env(**kwargs):
+    env = raw_env(**kwargs)
     env = wrappers.TerminateIllegalWrapper(env, illegal_reward=-1)
     env = wrappers.AssertOutOfBoundsWrapper(env)
     env = wrappers.NaNRandomWrapper(env)
@@ -26,14 +26,11 @@ class raw_env(AECEnv):
 
     metadata = {'render.modes': ['human']}
 
-    def __init__(self, seed=None, knock_reward: float = 0.5, gin_reward: float = 1.0, **kwargs):
+    def __init__(self, seed=None, knock_reward: float = 0.5, gin_reward: float = 1.0):
         super().__init__()
-        if seed is not None:
-            np.random.seed(seed)
-            random.seed(seed)
         self._knock_reward = knock_reward
         self._gin_reward = gin_reward
-        self.env = rlcard.make('gin-rummy', **kwargs)
+        self.env = rlcard.make('gin-rummy', config={"seed": seed})
         self.agents = ['player_0', 'player_1']
         self.num_agents = len(self.agents)
         self.has_reset = False
@@ -130,7 +127,7 @@ class raw_env(AECEnv):
 
     def reset(self, observe=True):
         self.has_reset = True
-        obs, player_id = self.env.init_game()
+        obs, player_id = self.env.reset()
         self.agent_order = [self._int_to_name(agent) for agent in [player_id, 0 if player_id == 1 else 1]]
         self._agent_selector.reinit(self.agent_order)
         self.agent_selection = self._agent_selector.reset()

--- a/pettingzoo/classic/leduc_holdem/leduc_holdem.py
+++ b/pettingzoo/classic/leduc_holdem/leduc_holdem.py
@@ -9,8 +9,8 @@ import numpy as np
 from pettingzoo.utils import wrappers
 
 
-def env():
-    env = raw_env()
+def env(**kwargs):
+    env = raw_env(**kwargs)
     env = wrappers.TerminateIllegalWrapper(env, illegal_reward=-1)
     env = wrappers.AssertOutOfBoundsWrapper(env)
     env = wrappers.NaNRandomWrapper(env)
@@ -22,12 +22,12 @@ class raw_env(AECEnv):
 
     metadata = {'render.modes': ['human']}
 
-    def __init__(self, seed=None, **kwargs):
+    def __init__(self, seed=None):
         super().__init__()
         if seed is not None:
             np.random.seed(seed)
             random.seed(seed)
-        self.env = rlcard.make('leduc-holdem', **kwargs)
+        self.env = rlcard.make('leduc-holdem', config={"seed": seed})
         self.agents = ['player_0', 'player_1']
         self.num_agents = len(self.agents)
         self.has_reset = False
@@ -88,7 +88,7 @@ class raw_env(AECEnv):
 
     def reset(self, observe=True):
         self.has_reset = True
-        obs, player_id = self.env.init_game()
+        obs, player_id = self.env.reset()
         self.agent_order = [self._int_to_name(agent) for agent in [player_id, 0 if player_id == 1 else 1]]
         self._agent_selector.reinit(self.agent_order)
         self.agent_selection = self._agent_selector.reset()

--- a/pettingzoo/classic/mahjong/mahjong.py
+++ b/pettingzoo/classic/mahjong/mahjong.py
@@ -8,8 +8,8 @@ import numpy as np
 from pettingzoo.utils import wrappers
 
 
-def env():
-    env = raw_env()
+def env(**kwargs):
+    env = raw_env(**kwargs)
     env = wrappers.TerminateIllegalWrapper(env, illegal_reward=-1)
     env = wrappers.AssertOutOfBoundsWrapper(env)
     env = wrappers.NaNRandomWrapper(env)
@@ -21,12 +21,9 @@ class raw_env(AECEnv):
 
     metadata = {'render.modes': ['human']}
 
-    def __init__(self, seed=None, **kwargs):
+    def __init__(self, seed=None):
         super().__init__()
-        if seed is not None:
-            np.random.seed(seed)
-            random.seed(seed)
-        self.env = rlcard.make('mahjong', **kwargs)
+        self.env = rlcard.make('mahjong', config={"seed": seed})
         self.agents = ['player_0', 'player_1', 'player_2', 'player_3']
         self.num_agents = len(self.agents)
         self.has_reset = False
@@ -107,7 +104,7 @@ class raw_env(AECEnv):
 
     def reset(self, observe=True):
         self.has_reset = True
-        obs, player_id = self.env.init_game()
+        obs, player_id = self.env.reset()
         self.agent_order = self.agents
         self._agent_selector = agent_selector(self.agent_order)
         self.agent_selection = self._agent_selector.reset()

--- a/pettingzoo/classic/texas_holdem/texas_holdem.py
+++ b/pettingzoo/classic/texas_holdem/texas_holdem.py
@@ -9,8 +9,8 @@ import numpy as np
 from pettingzoo.utils import wrappers
 
 
-def env():
-    env = raw_env()
+def env(**kwargs):
+    env = raw_env(**kwargs)
     env = wrappers.TerminateIllegalWrapper(env, illegal_reward=-1)
     env = wrappers.AssertOutOfBoundsWrapper(env)
     env = wrappers.NaNRandomWrapper(env)
@@ -22,12 +22,12 @@ class raw_env(AECEnv):
 
     metadata = {'render.modes': ['human']}
 
-    def __init__(self, seed=None, **kwargs):
+    def __init__(self, seed=None):
         super().__init__()
         if seed is not None:
             np.random.seed(seed)
             random.seed(seed)
-        self.env = rlcard.make('limit-holdem', **kwargs)
+        self.env = rlcard.make('limit-holdem', config={"seed": seed},)
         self.agents = ['player_0', 'player_1']
         self.num_agents = len(self.agents)
         self.has_reset = False
@@ -90,7 +90,7 @@ class raw_env(AECEnv):
 
     def reset(self, observe=True):
         self.has_reset = True
-        obs, player_id = self.env.init_game()
+        obs, player_id = self.env.reset()
         self.agent_order = [self._int_to_name(agent) for agent in [player_id, 0 if player_id == 1 else 1]]
         self._agent_selector.reinit(self.agent_order)
         self.agent_selection = self._agent_selector.reset()

--- a/pettingzoo/classic/texas_holdem_no_limit/texas_holdem_no_limit.py
+++ b/pettingzoo/classic/texas_holdem_no_limit/texas_holdem_no_limit.py
@@ -9,8 +9,8 @@ import numpy as np
 from pettingzoo.utils import wrappers
 
 
-def env():
-    env = raw_env()
+def env(**kwargs):
+    env = raw_env(**kwargs)
     env = wrappers.TerminateIllegalWrapper(env, illegal_reward=-1)
     env = wrappers.AssertOutOfBoundsWrapper(env)
     env = wrappers.NaNRandomWrapper(env)
@@ -22,12 +22,12 @@ class raw_env(AECEnv):
 
     metadata = {'render.modes': ['human']}
 
-    def __init__(self, seed=None, **kwargs):
+    def __init__(self, seed=None):
         super().__init__()
         if seed is not None:
             np.random.seed(seed)
             random.seed(seed)
-        self.env = rlcard.make('no-limit-holdem', **kwargs)
+        self.env = rlcard.make('no-limit-holdem', config={"seed": seed})
         self.agents = ['player_0', 'player_1']
         self.num_agents = len(self.agents)
         self.has_reset = False
@@ -90,7 +90,7 @@ class raw_env(AECEnv):
 
     def reset(self, observe=True):
         self.has_reset = True
-        obs, player_id = self.env.init_game()
+        obs, player_id = self.env.reset()
         self.agent_order = [self._int_to_name(agent) for agent in [player_id, 0 if player_id == 1 else 1]]
         self._agent_selector.reinit(self.agent_order)
         self.agent_selection = self._agent_selector.reset()

--- a/pettingzoo/classic/uno/uno.py
+++ b/pettingzoo/classic/uno/uno.py
@@ -9,8 +9,8 @@ import numpy as np
 from pettingzoo.utils import wrappers
 
 
-def env():
-    env = raw_env()
+def env(**kwargs):
+    env = raw_env(**kwargs)
     env = wrappers.TerminateIllegalWrapper(env, illegal_reward=-1)
     env = wrappers.AssertOutOfBoundsWrapper(env)
     env = wrappers.NaNRandomWrapper(env)
@@ -22,12 +22,12 @@ class raw_env(AECEnv):
 
     metadata = {'render.modes': ['human']}
 
-    def __init__(self, seed=None, **kwargs):
+    def __init__(self, seed=None):
         super().__init__()
         if seed is not None:
             np.random.seed(seed)
             random.seed(seed)
-        self.env = rlcard.make('uno', **kwargs)
+        self.env = rlcard.make('uno', config={"seed": seed})
         self.agents = ['player_0', 'player_1']
         self.num_agents = len(self.agents)
         self.has_reset = False
@@ -97,7 +97,7 @@ class raw_env(AECEnv):
 
     def reset(self, observe=True):
         self.has_reset = True
-        obs, player_id = self.env.init_game()
+        obs, player_id = self.env.reset()
         self.agent_order = [self.agents[agent] for agent in [player_id, 0 if player_id == 1 else 1]]
         self._agent_selector.reinit(self.agent_order)
         self.agent_selection = self._agent_selector.reset()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ numpy>=1.18.0
 pymunk>=5.6.0
 gym[box2d]>=0.15.4
 python-chess
-rlcard >= 0.1.14
+rlcard >= 0.2.1
 pynput
 opencv-python


### PR DESCRIPTION
Is the `**kwargs` in the environment argument needed? I removed them since it could conflict with the way seeding is handled in the new rlcard environments, but I don't know if they served some purpose before that we need to work out.