### PR TITLE
added max frames to magent and mpe

### DIFF
--- a/docs/atari.md
+++ b/docs/atari.md
@@ -47,7 +47,7 @@ env = frame_skip(env, 4)
 All the Atari environments have the following environment parameters:
 
 ```
-<atar_game>.env(seed=None, obs_type='rgb_image', repeat_action_probability=0.25, full_action_space=True)
+<atar_game>.env(seed=None, obs_type='rgb_image', repeat_action_probability=0.25, full_action_space=True, max_frames=100000)
 ```
 
 ```
@@ -58,6 +58,8 @@ obs_type: default value of 'rgb_image' leads to (210, 160, 3) image pixel observ
 repeat_action_probability: probability you repeat an action from the previous frame (not step, frame), even after you have chosen a new action. Simulates the joystick getting stuck and not responding 100% quickly to moves.
 
 full_action_space: The effective action space of the atari games is often smaller than the full space of 18 moves. Setting this to False shrinks the action space to this smaller space.
+
+max_frames: number of frames (a step for each agent) until game terminates
 ```
 
 ### Citation

--- a/docs/magent/adversarial_pursuit.md
+++ b/docs/magent/adversarial_pursuit.md
@@ -44,11 +44,13 @@ Observation space: `[empty, obstacle, predators, prey, one_hot_action, last_rewa
 Map size: 45x45
 
 ```
-adversarial_pursuit_v0.env(seed=None, attack_penalty=-0.2)
+adversarial_pursuit_v0.env(seed=None, attack_penalty=-0.2, max_frames=500)
 ```
 
 ```
 seed: seed for random values. Set to None to use machine random source. Set to fixed value for deterministic behavior.
 
 attack_penalty: Adds the following value to the reward whenever an attacking action is taken
+
+max_frames: number of frames (a step for each agent) until game terminates
 ```

--- a/docs/magent/battle.md
+++ b/docs/magent/battle.md
@@ -45,7 +45,7 @@ Observation space: `[empty, obstacle, red, blue, minimap_red, minimap_blue, bina
 Map size: 45x45
 
 ```
-battle_v0.env(seed=None, step_reward-0.005, dead_penalty=-0.1, attack_penalty=-0.1, attack_opponent_reward=0.2)
+battle_v0.env(seed=None, step_reward-0.005, dead_penalty=-0.1, attack_penalty=-0.1, attack_opponent_reward=0.2, max_frames=1000)
 ```
 
 ```
@@ -58,4 +58,6 @@ dead_penalty: reward added when killed
 attack_penalty: reward added for attacking
 
 attack_opponent_reward: Reward added for attacking an opponent
+
+max_frames: number of frames (a step for each agent) until game terminates
 ```

--- a/docs/magent/battlefield.md
+++ b/docs/magent/battlefield.md
@@ -47,7 +47,7 @@ Observation space: `[empty, obstacle, red, blue, minimap_red, minimap_blue, bina
 Map size: 80x80
 
 ```
-battle_v0.env(seed=None, step_reward-0.005, dead_penalty=-0.1, attack_penalty=-0.1, attack_opponent_reward=0.2)
+battle_v0.env(seed=None, step_reward-0.005, dead_penalty=-0.1, attack_penalty=-0.1, attack_opponent_reward=0.2, max_frames=1000)
 ```
 
 ```
@@ -60,4 +60,6 @@ dead_penalty: reward added when killed
 attack_penalty: reward added for attacking
 
 attack_opponent_reward: Reward added for attacking an opponent
+
+max_frames: number of frames (a step for each agent) until game terminates
 ```

--- a/docs/magent/combined_arms.md
+++ b/docs/magent/combined_arms.md
@@ -46,7 +46,7 @@ Observation space: `[empty, obstacle, agent_maps, agent_minimaps, binary_agent_i
 Map size: 45x45
 
 ```
-combined_arms_v0.env(seed=None, step_reward-0.01, dead_penalty=-0.1, attack_penalty=-1, attack_opponent_reward=2)
+combined_arms_v0.env(seed=None, step_reward-0.01, dead_penalty=-0.1, attack_penalty=-1, attack_opponent_reward=2, max_frames=1000)
 ```
 
 ```
@@ -59,4 +59,6 @@ dead_penalty: reward added when killed
 attack_penalty: reward added for attacking
 
 attack_opponent_reward: Reward added for attacking an opponent
+
+max_frames: number of frames (a step for each agent) until game terminates
 ```

--- a/docs/magent/gather.md
+++ b/docs/magent/gather.md
@@ -41,7 +41,7 @@ Observation space: `[empty, obstacle, omnivore, food, omnivore_minimap, food_min
 Map size: 200x200
 
 ```
-gather_v0.env(seed=None, step_reward=-0.01, attack_penalty=-0.1, dead_penalty=-1, attack_food_reward=0.5)
+gather_v0.env(seed=None, step_reward=-0.01, attack_penalty=-0.1, dead_penalty=-1, attack_food_reward=0.5, max_frames=500)
 ```
 
 ```
@@ -54,4 +54,6 @@ dead_penalty: reward added when killed
 attack_penalty: reward added for attacking
 
 attack_food_reward: Reward added for attacking a food
+
+max_frames: number of frames (a step for each agent) until game terminates
 ```

--- a/docs/magent/tiger_deer.md
+++ b/docs/magent/tiger_deer.md
@@ -44,9 +44,11 @@ Observation space: `[empty, obstacle, deer, tigers, binary_agent_id(10), one_hot
 Map size: 45x45
 
 ```
-tiger_deer_v0.env(seed=None)
+tiger_deer_v0.env(seed=None, max_frames=500)
 ```
 
 ```
 seed: seed for random values. Set to None to use machine random source. Set to fixed value for deterministic behavior.
+
+max_frames: number of frames (a step for each agent) until game terminates
 ```

--- a/pettingzoo/atari/base_atari_env.py
+++ b/pettingzoo/atari/base_atari_env.py
@@ -35,7 +35,8 @@ class ParallelAtariEnv:
             seed=None,
             obs_type='rgb_image',
             repeat_action_probability=0.25,
-            full_action_space=True):
+            full_action_space=True,
+            max_frames=100000):
         """Frameskip should be either a tuple (indicating a random range to
         choose from, with the top value exclude), or an int."""
 
@@ -44,6 +45,7 @@ class ParallelAtariEnv:
         self.full_action_space = full_action_space
         self.num_players = num_players
         self.np_random = seeding.np_random(seed)
+        self.max_frames = max_frames
 
         multi_agent_ale_py.ALEInterface.setLoggerMode("error")
         self.ale = multi_agent_ale_py.ALEInterface()
@@ -102,6 +104,7 @@ class ParallelAtariEnv:
 
     def reset(self):
         self.ale.reset_game()
+        self.frame = 0
 
         return [self._observe()] * self.num_agents
 
@@ -118,13 +121,14 @@ class ParallelAtariEnv:
         actions = np.asarray(actions)
         actions = self.action_mapping[actions]
         rewards = self.ale.act(actions)
-        if self.ale.game_over():
+        if self.ale.game_over() or self.frame >= self.max_frames:
             dones = [True] * self.num_agents
         else:
             lives = self.ale.allLives()
             # an inactive agent in ale gets a -1 life.
             dones = [int(life) < 0 for life in lives]
 
+        self.frame += 1
         observations = [self._observe()] * self.num_agents
         infos = [{}] * self.num_agents
         return observations, rewards, dones, infos

--- a/pettingzoo/magent/adversarial_pursuit_v0.py
+++ b/pettingzoo/magent/adversarial_pursuit_v0.py
@@ -10,9 +10,9 @@ from .magent_env import magent_parallel_env, make_env
 from pettingzoo.utils._parallel_env import _parallel_env_wrapper
 
 
-def raw_env(seed=None, **reward_args):
+def raw_env(seed=None, max_frames=500, **reward_args):
     map_size = 45
-    return _parallel_env_wrapper(_parallel_env(map_size, reward_args, seed))
+    return _parallel_env_wrapper(_parallel_env(map_size, reward_args, max_frames, seed))
 
 
 env = make_env(raw_env)
@@ -55,13 +55,13 @@ def get_config(map_size, attack_penalty=-0.2):
 
 
 class _parallel_env(magent_parallel_env):
-    def __init__(self, map_size, reward_args, seed):
+    def __init__(self, map_size, reward_args, max_frames, seed):
         env = magent.GridWorld(get_config(map_size, **reward_args), map_size=map_size)
 
         handles = env.get_handles()
 
         names = ["predator", "prey"]
-        super().__init__(env, handles, names, map_size, seed)
+        super().__init__(env, handles, names, map_size, max_frames, seed)
 
     def generate_map(self):
         env, map_size = self.env, self.map_size

--- a/pettingzoo/magent/battle_v0.py
+++ b/pettingzoo/magent/battle_v0.py
@@ -10,9 +10,9 @@ from .magent_env import magent_parallel_env, make_env
 from pettingzoo.utils._parallel_env import _parallel_env_wrapper
 
 
-def raw_env(seed=None, **reward_args):
+def raw_env(seed=None, max_frames=1000, **reward_args):
     map_size = 45
-    return _parallel_env_wrapper(_parallel_env(map_size, reward_args, seed))
+    return _parallel_env_wrapper(_parallel_env(map_size, reward_args, max_frames, seed))
 
 
 env = make_env(raw_env)
@@ -51,12 +51,12 @@ def get_config(map_size, step_reward=-0.005, dead_penalty=-0.1, attack_penalty=-
 
 
 class _parallel_env(magent_parallel_env):
-    def __init__(self, map_size, reward_args, seed):
+    def __init__(self, map_size, reward_args, max_frames, seed):
         env = magent.GridWorld(get_config(map_size, **reward_args), map_size=map_size)
         self.leftID = 0
         self.rightID = 1
         names = ["red", "blue"]
-        super().__init__(env, env.get_handles(), names, map_size, seed)
+        super().__init__(env, env.get_handles(), names, map_size, max_frames, seed)
 
     def generate_map(self):
         env, map_size, handles = self.env, self.map_size, self.handles

--- a/pettingzoo/magent/battlefield_v0.py
+++ b/pettingzoo/magent/battlefield_v0.py
@@ -11,21 +11,21 @@ from pettingzoo.utils._parallel_env import _parallel_env_wrapper
 from .battle_v0 import get_config
 
 
-def raw_env(seed=None, **reward_args):
+def raw_env(seed=None, max_frames=1000, **reward_args):
     map_size = 80
-    return _parallel_env_wrapper(_parallel_env(map_size, reward_args, seed))
+    return _parallel_env_wrapper(_parallel_env(map_size, reward_args, max_frames, seed))
 
 
 env = make_env(raw_env)
 
 
 class _parallel_env(magent_parallel_env):
-    def __init__(self, map_size, reward_args, seed):
+    def __init__(self, map_size, reward_args, max_frames, seed):
         env = magent.GridWorld(get_config(map_size, **reward_args), map_size=map_size)
         self.leftID = 0
         self.rightID = 1
         names = ["red", "blue"]
-        super().__init__(env, env.get_handles(), names, map_size, seed)
+        super().__init__(env, env.get_handles(), names, map_size, max_frames, seed)
 
     def generate_map(self):
         env, map_size, handles = self.env, self.map_size, self.handles

--- a/pettingzoo/magent/combined_arms_v0.py
+++ b/pettingzoo/magent/combined_arms_v0.py
@@ -10,9 +10,9 @@ from .magent_env import magent_parallel_env, make_env
 from pettingzoo.utils._parallel_env import _parallel_env_wrapper
 
 
-def raw_env(seed=None, **reward_args):
+def raw_env(seed=None, max_frames=1000, **reward_args):
     map_size = 45
-    return _parallel_env_wrapper(_parallel_env(map_size, reward_args, seed))
+    return _parallel_env_wrapper(_parallel_env(map_size, reward_args, max_frames, seed))
 
 
 env = make_env(raw_env)
@@ -119,10 +119,10 @@ def generate_map(env, map_size, handles):
 
 
 class _parallel_env(magent_parallel_env):
-    def __init__(self, map_size, reward_args, seed):
+    def __init__(self, map_size, reward_args, max_frames, seed):
         env = magent.GridWorld(load_config(map_size, **reward_args))
         names = ["redmelee", "redranged", "bluemele", "blueranged"]
-        super().__init__(env, env.get_handles(), names, map_size, seed)
+        super().__init__(env, env.get_handles(), names, map_size, max_frames, seed)
 
     def generate_map(self):
         generate_map(self.env, self.map_size, self.handles)

--- a/pettingzoo/magent/gather_v0.py
+++ b/pettingzoo/magent/gather_v0.py
@@ -10,9 +10,9 @@ from .magent_env import magent_parallel_env, make_env
 from pettingzoo.utils._parallel_env import _parallel_env_wrapper
 
 
-def raw_env(seed=None, **reward_args):
+def raw_env(seed=None, max_frames=500, **reward_args):
     map_size = 200
-    return _parallel_env_wrapper(_parallel_env(map_size, reward_args, seed))
+    return _parallel_env_wrapper(_parallel_env(map_size, reward_args, max_frames, seed))
 
 
 env = make_env(raw_env)
@@ -56,12 +56,12 @@ def load_config(size, step_reward=-0.01, attack_penalty=-0.1, dead_penalty=-1, a
 
 
 class _parallel_env(magent_parallel_env):
-    def __init__(self, map_size, reward_args, seed):
+    def __init__(self, map_size, reward_args, max_frames, seed):
         env = magent.GridWorld(load_config(map_size, **reward_args))
         handles = env.get_handles()
 
         names = ["omnivore"]
-        super().__init__(env, handles[1:], names, map_size, seed)
+        super().__init__(env, handles[1:], names, map_size, max_frames, seed)
 
     def generate_map(self):
         env, map_size = self.env, self.map_size

--- a/pettingzoo/magent/tiger_deer_v0.py
+++ b/pettingzoo/magent/tiger_deer_v0.py
@@ -10,9 +10,9 @@ from .magent_env import magent_parallel_env, make_env
 from pettingzoo.utils._parallel_env import _parallel_env_wrapper
 
 
-def raw_env(seed=None):
+def raw_env(seed=None, max_frames=300):
     map_size = 45
-    return _parallel_env_wrapper(_parallel_env(map_size, seed))
+    return _parallel_env_wrapper(_parallel_env(map_size, max_frames, seed))
 
 
 env = make_env(raw_env)
@@ -61,13 +61,13 @@ def get_config(map_size):
 
 
 class _parallel_env(magent_parallel_env):
-    def __init__(self, map_size, seed):
+    def __init__(self, map_size, max_frames, seed):
         env = magent.GridWorld(get_config(map_size), map_size=map_size)
 
         handles = env.get_handles()
 
         names = ["deer", "tiger"]
-        super().__init__(env, handles, names, map_size, seed)
+        super().__init__(env, handles, names, map_size, max_frames, seed)
 
     def generate_map(self):
         env, map_size = self.env, self.map_size


### PR DESCRIPTION
Now only classic does not have a max-frames parameter, which should be fine, because they all terminate in a predictable amount of time (I believe go is currently the longest at 600). 