### PR TITLE
Updated the pettingzoo.tests.performance_benchmark function to display output as mean ± stdev

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -115,10 +115,10 @@ This randomly plays through the environment `cycles` times, to test for stabilit
 
 ```
 import pettingzoo.tests.performance_benchmark as performance_benchmark
-performance_benchmark.performance_benchmark(env)
+performance_benchmark.performance_benchmark(env, overall_test_time=5, single_run_time=1, check_benchmark_stability=True)
 ```
 
-This randomly steps through the environment for 60 seconds to benchmark it's performance.
+This randomly steps through the environment for 5 seconds to benchmark it's performance. The performance benchmark is composed of multiple runs, you can set the overall time for which the benchmark runs through the `overall_test_time` argument in seconds. You may also fine-tune your benchmark by controlling the execution time for which each run through the `single_run_time` argument. Note that `overall_test_time` must be a multiple of `single_run_time`. If `check_benchmark_stability=True`, the benchmark results are checked for stability.
 
 ### Manual Control Test
 

--- a/pettingzoo/tests/performance_benchmark.py
+++ b/pettingzoo/tests/performance_benchmark.py
@@ -37,7 +37,7 @@ def _performance_benchmark(env, test_sample_time):
     return cycles_per_time, turns_per_time
 
 
-def check_stability(name, arr):
+def _check_benchmark_stability(name, arr):
     # Stability check based on the pyperf standard at
     # https://pyperf.readthedocs.io/en/latest/cli.html#pyperf-check
     mean = arr.mean()
@@ -56,12 +56,8 @@ def check_stability(name, arr):
         print(f"[WARNING] for {name} maximum is 50% greater than the mean", file=sys.stderr)
 
 
-def performance_benchmark(env):
+def performance_benchmark(env, test_time=5, test_sample_time=1, check_benchmark_stability=True):
     print("Starting performance benchmark")
-
-    test_time = 5
-    test_sample_time = 1
-    check_benchmark_stability = True
 
     assert test_time % test_sample_time == 0, "'test_time' should be a multiple of 'test_sample_time'"
 
@@ -76,8 +72,8 @@ def performance_benchmark(env):
     cycles_times = np.array(cycles_times)
 
     if (check_benchmark_stability):
-        check_stability("turns", turns_times)
-        check_stability("cycles", turns_times)
+        _check_benchmark_stability("turns", turns_times)
+        _check_benchmark_stability("cycles", cycles_times)
 
     print("{0:.2f} +- {1:.2f} turns  per second".format(turns_times.mean(), turns_times.std()))
     print("{0:.2f} +- {1:.2f} cycles per second".format(cycles_times.mean(), cycles_times.std()))

--- a/pettingzoo/tests/performance_benchmark.py
+++ b/pettingzoo/tests/performance_benchmark.py
@@ -4,7 +4,7 @@ import random
 import numpy as np
 
 
-def _performance_benchmark(env, test_sample_time):
+def _performance_benchmark(env, single_run_time):
     cycles = 0
     turn = 0
     _ = env.reset()
@@ -25,7 +25,7 @@ def _performance_benchmark(env, test_sample_time):
             if all(env.dones.values()):
                 _ = env.reset()
 
-        if time.process_time() - start > test_sample_time:
+        if time.process_time() - start > single_run_time:
             end = time.process_time()
             break
 
@@ -56,15 +56,15 @@ def _check_benchmark_stability(name, arr):
         print(f"[WARNING] for {name} maximum is 50% greater than the mean", file=sys.stderr)
 
 
-def performance_benchmark(env, test_time=5, test_sample_time=1, check_benchmark_stability=True):
+def performance_benchmark(env, overall_test_time=5, single_run_time=1, check_benchmark_stability=True):
     print("Starting performance benchmark")
 
-    assert test_time % test_sample_time == 0, "'test_time' should be a multiple of 'test_sample_time'"
+    assert overall_test_time % single_run_time == 0, "'overall_test_time' should be a multiple of 'single_run_time'"
 
     cycles_times = []
     turns_times = []
-    for test_idx in range(int(test_time / test_sample_time)):
-        cycle_time, turns_time = _performance_benchmark(env, test_sample_time)
+    for test_idx in range(int(overall_test_time / single_run_time)):
+        cycle_time, turns_time = _performance_benchmark(env, single_run_time)
         turns_times.append(turns_time)
         cycles_times.append(cycle_time)
 


### PR DESCRIPTION
to make multiple smaller runs and report results in the
mean ± stdev format.

Commit related to #170.