### PR TITLE
Update __init__.py

### DIFF
--- a/pettingzoo/sisl/__init__.py
+++ b/pettingzoo/sisl/__init__.py
@@ -1,6 +1,6 @@
 from pettingzoo.utils.depreciated_module import DepreciatedModule
 
 multiwalker_v0 = DepreciatedModule("multiwalker", "v0", "v2")
-multiwalker_v0 = DepreciatedModule("multiwalker", "v0", "v2")
+multiwalker_v1 = DepreciatedModule("multiwalker", "v1", "v2")
 pursuit_v0 = DepreciatedModule("pursuit", "v0", "v1")
 waterworld_v0 = DepreciatedModule("waterworld", "v0", "v1")


### PR DESCRIPTION
bug: 
+ the line `multiwalker_v0 = DepreciatedModule("multiwalker", "v0", "v2")` was duplicated on 2 lines. 
+ This causes an error when trying to import multiwalker_v1: `ImportError: cannot import name 'multiwalker_v1' from 'pettingzoo.sisl' (/home/ross/miniconda3/envs/pettingzoo_rllib/lib/python3.8/site-packages/pettingzoo/sisl/__init__.py)`

fix: I believe the intent was to make `multiwalker_v1` a `DepreciatedModule` like `multiwalker_v0`