### PR TITLE
Removed opponent's hands from RLcard observation

### DIFF
--- a/docs/classic/dou_dizhu.md
+++ b/docs/classic/dou_dizhu.md
@@ -24,10 +24,10 @@ Our implementation wraps [RLCard](http://rlcard.org/games.html#dou-dizhu) and yo
 ### Environment parameters
 
 ```
-dou_dizhu.env(full_observation_space=False)
+dou_dizhu.env(opponents_hand_visible=False)
 ```
 
-`full_observation_space`:  Set to `True` to observe the entire observation space as described in `Observation Space` below. Setting it to `False` will remove any observation of the opponent' hands and the observation space will only include planes 0, 2, 3, and 4. 
+`opponents_hand_visible`:  Set to `True` to observe the entire observation space as described in `Observation Space` below. Setting it to `False` will remove any observation of the opponent' hands and the observation space will only include planes 0, 2, 3, and 4. 
 
 #### Observation Space
 

--- a/docs/classic/dou_dizhu.md
+++ b/docs/classic/dou_dizhu.md
@@ -21,7 +21,13 @@ The "Landlord" plays first by putting down a combination of cards. The next play
 
 Our implementation wraps [RLCard](http://rlcard.org/games.html#dou-dizhu) and you can refer to its documentation for additional details. Please cite their work if you use this game in research.
 
+### Environment parameters
 
+```
+dou_dizhu.env(full_observation_space=False)
+```
+
+`full_observation_space`:  Set to `True` to observe the entire observation space as described in `Observation Space` below. Setting it to `False` will remove any observation of the opponent' hands and the observation space will only include planes 0, 2, 3, and 4. 
 
 #### Observation Space
 
@@ -94,3 +100,5 @@ We modified the reward structure compared to RLCard. Instead of rewarding `0` to
 #### Legal Moves
 
 The legal moves available for each agent, found in `env.infos[agent]['legal_moves']`, are updated after each step. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
+
+

--- a/docs/classic/gin_rummy.md
+++ b/docs/classic/gin_rummy.md
@@ -26,13 +26,14 @@ Our implementation wraps [RLCard](http://rlcard.org/games.html#gin-rummy) and yo
 Gin Rummy takes two optional arguments that define the reward received by a player who knocks or goes gin. The default values for the knock reward and gin reward are 0.5 and 1.0, respectively.
 
 ```
-gin_rummy.env(knock_reward = 0.5, gin_reward = 1.0)
+gin_rummy.env(knock_reward = 0.5, gin_reward = 1.0, full_observation_space = False)
 ```
 
 `knock_reward`:  reward received by a player who knocks
 
 `gin_reward`:  reward received by a player who goes gin
 
+`full_observation_space`:  Set to `True` to observe the entire observation space as described in `Observation Space` below. Setting it to `False` will remove any observation of the unknown cards and the observation space will only include planes 0 to 3. 
 
 #### Observation Space
 

--- a/docs/classic/gin_rummy.md
+++ b/docs/classic/gin_rummy.md
@@ -26,14 +26,14 @@ Our implementation wraps [RLCard](http://rlcard.org/games.html#gin-rummy) and yo
 Gin Rummy takes two optional arguments that define the reward received by a player who knocks or goes gin. The default values for the knock reward and gin reward are 0.5 and 1.0, respectively.
 
 ```
-gin_rummy.env(knock_reward = 0.5, gin_reward = 1.0, full_observation_space = False)
+gin_rummy.env(knock_reward = 0.5, gin_reward = 1.0, opponents_hand_visible = False)
 ```
 
 `knock_reward`:  reward received by a player who knocks
 
 `gin_reward`:  reward received by a player who goes gin
 
-`full_observation_space`:  Set to `True` to observe the entire observation space as described in `Observation Space` below. Setting it to `False` will remove any observation of the unknown cards and the observation space will only include planes 0 to 3. 
+`opponents_hand_visible`:  Set to `True` to observe the entire observation space as described in `Observation Space` below. Setting it to `False` will remove any observation of the unknown cards and the observation space will only include planes 0 to 3. 
 
 #### Observation Space
 

--- a/docs/classic/uno.md
+++ b/docs/classic/uno.md
@@ -19,6 +19,14 @@ Uno is shedding game involving 2 players. At the beginning, each player receives
 
 Our implementation wraps [RLCard](http://rlcard.org/games.html#uno) and you can refer to its documentation for additional details. Please cite their work if you use this game in research.
 
+### Environment parameters
+
+```
+uno.env(full_observation_space=False)
+```
+
+`full_observation_space`:  Set to `True` to observe the entire observation space as described in `Observation Space` below. Setting it to `False` will remove any observation of the opponent' hands and the observation space will only include planes 0 to 3.
+ 
 #### Observation Space
 
 The observation space has a shape of (7, 4, 15). Planes 0-2 represent the current player's hand, while planes 4-6 represent the opponent's hand. For these sets of planes, the first index indicates the number of copies of a card, the second index the color, and the last index the card number (including any special cards). Uno is played with 2 identical decks, so a player can have 0, 1, or 2 copies of a given card, which is why each player has 3 planes to represent their hand. 
@@ -90,3 +98,4 @@ For example, you would use action `6` to put down a red "6" card or action `60` 
 #### Legal Moves
 
 The legal moves available for each agent, found in `env.infos[agent]['legal_moves']`, are updated after each step. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
+

--- a/docs/classic/uno.md
+++ b/docs/classic/uno.md
@@ -22,10 +22,10 @@ Our implementation wraps [RLCard](http://rlcard.org/games.html#uno) and you can 
 ### Environment parameters
 
 ```
-uno.env(full_observation_space=False)
+uno.env(opponents_hand_visible=False)
 ```
 
-`full_observation_space`:  Set to `True` to observe the entire observation space as described in `Observation Space` below. Setting it to `False` will remove any observation of the opponent' hands and the observation space will only include planes 0 to 3.
+`opponents_hand_visible`:  Set to `True` to observe the entire observation space as described in `Observation Space` below. Setting it to `False` will remove any observation of the opponent' hands and the observation space will only include planes 0 to 3.
  
 #### Observation Space
 

--- a/pettingzoo/classic/rlcard_envs/dou_dizhu.py
+++ b/pettingzoo/classic/rlcard_envs/dou_dizhu.py
@@ -23,10 +23,10 @@ class raw_env(RLCardBase):
 
     metadata = {'render.modes': ['human']}
 
-    def __init__(self, full_observation_space=False):
-        self._full_observation_space = full_observation_space
+    def __init__(self, opponents_hand_visible=False):
+        self._opponents_hand_visible = opponents_hand_visible
         self.agents = ['landlord_0', 'peasant_0', 'peasant_1']
-        num_planes = 6 if self._full_observation_space else 4
+        num_planes = 6 if self._opponents_hand_visible else 4
         super().__init__("doudizhu", 3, (num_planes, 5, 15))
 
     def _scale_rewards(self, reward):
@@ -35,7 +35,7 @@ class raw_env(RLCardBase):
 
     def observe(self, agent):
         obs = self.env.get_state(self._name_to_int(agent))
-        if self._full_observation_space:
+        if self._opponents_hand_visible:
             return obs['obs'].astype(self._dtype)
         else:
             return obs['obs'][[0, 2, 3, 4], :, :].astype(self._dtype)

--- a/pettingzoo/classic/rlcard_envs/dou_dizhu.py
+++ b/pettingzoo/classic/rlcard_envs/dou_dizhu.py
@@ -23,18 +23,27 @@ class raw_env(RLCardBase):
 
     metadata = {'render.modes': ['human']}
 
-    def __init__(self):
+    def __init__(self, full_observation_space=False):
+        self._full_observation_space = full_observation_space
         self.agents = ['landlord_0', 'peasant_0', 'peasant_1']
-        super().__init__("doudizhu", 3, (6, 5, 15))
+        num_planes = 6 if self._full_observation_space else 4
+        super().__init__("doudizhu", 3, (num_planes, 5, 15))
 
     def _scale_rewards(self, reward):
         # Maps 1 to 1 and 0 to -1
         return 2 * reward - 1
 
+    def observe(self, agent):
+        obs = self.env.get_state(self._name_to_int(agent))
+        if self._full_observation_space:
+            return obs['obs'].astype(self._dtype)
+        else:
+            return obs['obs'][[0,2,3,4],:,:].astype(self._dtype)
+
     def render(self, mode='human'):
         for player in self.agents:
             state = self.env.game.get_state(self._name_to_int(player))
-            print("\n===== {}'s Hand ({}) =====".format(player, 'Landlord' if player == 0 else 'Peasant'))
+            print("\n===== {}'s Hand =====".format(player))
             print(state['current_hand'])
         print('\n=========== Last 3 Actions ===========')
         for action in state['trace'][:-4:-1]:

--- a/pettingzoo/classic/rlcard_envs/dou_dizhu.py
+++ b/pettingzoo/classic/rlcard_envs/dou_dizhu.py
@@ -38,7 +38,7 @@ class raw_env(RLCardBase):
         if self._full_observation_space:
             return obs['obs'].astype(self._dtype)
         else:
-            return obs['obs'][[0,2,3,4],:,:].astype(self._dtype)
+            return obs['obs'][[0, 2, 3, 4], :, :].astype(self._dtype)
 
     def render(self, mode='human'):
         for player in self.agents:

--- a/pettingzoo/classic/rlcard_envs/gin_rummy.py
+++ b/pettingzoo/classic/rlcard_envs/gin_rummy.py
@@ -28,10 +28,10 @@ class raw_env(RLCardBase, EzPickle):
 
     metadata = {'render.modes': ['human']}
 
-    def __init__(self, knock_reward: float = 0.5, gin_reward: float = 1.0, full_observation_space=False):
+    def __init__(self, knock_reward: float = 0.5, gin_reward: float = 1.0, opponents_hand_visible=False):
         EzPickle.__init__(self, knock_reward, gin_reward)
-        self._full_observation_space = full_observation_space
-        num_planes = 5 if self._full_observation_space else 4
+        self._opponents_hand_visible = opponents_hand_visible
+        num_planes = 5 if self._opponents_hand_visible else 4
         RLCardBase.__init__(self, "gin-rummy", 2, (num_planes, 52))
         self._knock_reward = knock_reward
         self._gin_reward = gin_reward
@@ -55,7 +55,7 @@ class raw_env(RLCardBase, EzPickle):
 
     def observe(self, agent):
         obs = self.env.get_state(self._name_to_int(agent))
-        if self._full_observation_space:
+        if self._opponents_hand_visible:
             return obs['obs'].astype(self._dtype)
         else:
             return obs['obs'][0:4, :].astype(self._dtype)

--- a/pettingzoo/classic/rlcard_envs/gin_rummy.py
+++ b/pettingzoo/classic/rlcard_envs/gin_rummy.py
@@ -58,7 +58,7 @@ class raw_env(RLCardBase, EzPickle):
         if self._full_observation_space:
             return obs['obs'].astype(self._dtype)
         else:
-            return obs['obs'][0:4,:].astype(self._dtype)
+            return obs['obs'][0:4, :].astype(self._dtype)
 
     def render(self, mode='human'):
         for player in self.agents:

--- a/pettingzoo/classic/rlcard_envs/gin_rummy.py
+++ b/pettingzoo/classic/rlcard_envs/gin_rummy.py
@@ -28,9 +28,11 @@ class raw_env(RLCardBase, EzPickle):
 
     metadata = {'render.modes': ['human']}
 
-    def __init__(self, knock_reward: float = 0.5, gin_reward: float = 1.0):
+    def __init__(self, knock_reward: float = 0.5, gin_reward: float = 1.0, full_observation_space=False):
         EzPickle.__init__(self, knock_reward, gin_reward)
-        RLCardBase.__init__(self, "gin-rummy", 2, (5, 52))
+        self._full_observation_space = full_observation_space
+        num_planes = 5 if self._full_observation_space else 4
+        RLCardBase.__init__(self, "gin-rummy", 2, (num_planes, 52))
         self._knock_reward = knock_reward
         self._gin_reward = gin_reward
 
@@ -50,6 +52,13 @@ class raw_env(RLCardBase, EzPickle):
             deadwood_count = utils.get_deadwood_count(hand, best_meld_cluster)
             payoff = -deadwood_count / 100
         return payoff
+
+    def observe(self, agent):
+        obs = self.env.get_state(self._name_to_int(agent))
+        if self._full_observation_space:
+            return obs['obs'].astype(self._dtype)
+        else:
+            return obs['obs'][0:4,:].astype(self._dtype)
 
     def render(self, mode='human'):
         for player in self.agents:

--- a/pettingzoo/classic/rlcard_envs/rlcard_base.py
+++ b/pettingzoo/classic/rlcard_envs/rlcard_base.py
@@ -51,7 +51,7 @@ class RLCardBase(AECEnv):
     def step(self, action, observe=True):
         obs, next_player_id = self.env.step(action)
         next_player = self._int_to_name(next_player_id)
-        self._last_obs = obs['obs']
+        self._last_obs = self.observe(self.agent_selection)
         if self.env.is_over():
             self.rewards = self._convert_to_dict(self._scale_rewards(self.env.get_payoffs()))
             self.infos[next_player]['legal_moves'] = []
@@ -60,7 +60,7 @@ class RLCardBase(AECEnv):
             self.infos[next_player]['legal_moves'] = obs['legal_actions']
         self.agent_selection = next_player
         if observe:
-            return obs['obs'].astype(self._dtype) if obs else self._last_obs.astype(self._dtype)
+            return self.observe(self.agent_selection) if obs else self._last_obs
 
     def reset(self, observe=True):
         obs, player_id = self.env.reset()

--- a/pettingzoo/classic/rlcard_envs/rlcard_base.py
+++ b/pettingzoo/classic/rlcard_envs/rlcard_base.py
@@ -71,7 +71,7 @@ class RLCardBase(AECEnv):
         self.infos[self._int_to_name(player_id)]['legal_moves'] = obs['legal_actions']
         self._last_obs = obs['obs']
         if observe:
-            return obs['obs'].astype(self._dtype)
+            return self.observe(self.agent_selection)
         else:
             return
 

--- a/pettingzoo/classic/rlcard_envs/uno.py
+++ b/pettingzoo/classic/rlcard_envs/uno.py
@@ -33,7 +33,7 @@ class raw_env(RLCardBase):
         if self._full_observation_space:
             return obs['obs'].astype(self._dtype)
         else:
-            return obs['obs'][0:4,:,:].astype(self._dtype)
+            return obs['obs'][0:4, :, :].astype(self._dtype)
 
     def render(self, mode='human'):
         for player in self.agents:

--- a/pettingzoo/classic/rlcard_envs/uno.py
+++ b/pettingzoo/classic/rlcard_envs/uno.py
@@ -23,8 +23,17 @@ class raw_env(RLCardBase):
 
     metadata = {'render.modes': ['human']}
 
-    def __init__(self):
-        super().__init__("uno", 2, (7, 4, 15))
+    def __init__(self, full_observation_space=False):
+        self._full_observation_space = full_observation_space
+        num_planes = 7 if self._full_observation_space else 4
+        super().__init__("uno", 2, (num_planes, 4, 15))
+
+    def observe(self, agent):
+        obs = self.env.get_state(self._name_to_int(agent))
+        if self._full_observation_space:
+            return obs['obs'].astype(self._dtype)
+        else:
+            return obs['obs'][0:4,:,:].astype(self._dtype)
 
     def render(self, mode='human'):
         for player in self.agents:

--- a/pettingzoo/classic/rlcard_envs/uno.py
+++ b/pettingzoo/classic/rlcard_envs/uno.py
@@ -23,14 +23,14 @@ class raw_env(RLCardBase):
 
     metadata = {'render.modes': ['human']}
 
-    def __init__(self, full_observation_space=False):
-        self._full_observation_space = full_observation_space
-        num_planes = 7 if self._full_observation_space else 4
+    def __init__(self, opponents_hand_visible=False):
+        self._opponents_hand_visible = opponents_hand_visible
+        num_planes = 7 if self._opponents_hand_visible else 4
         super().__init__("uno", 2, (num_planes, 4, 15))
 
     def observe(self, agent):
         obs = self.env.get_state(self._name_to_int(agent))
-        if self._full_observation_space:
+        if self._opponents_hand_visible:
             return obs['obs'].astype(self._dtype)
         else:
             return obs['obs'][0:4, :, :].astype(self._dtype)


### PR DESCRIPTION
Updated Uno, Dou Dizhu, and Gin Rummy environments to remove the opponent's hand from the observation space. I added an environment argument, `full_observation_space`, to specify if the full observation space should be returned every time that `observe()` is called. 

Also, I updated the docs accordingly.  