### PR TITLE
fixed multiwalker stepping

### DIFF
--- a/pettingzoo/sisl/multiwalker/multiwalker_base.py
+++ b/pettingzoo/sisl/multiwalker/multiwalker_base.py
@@ -442,9 +442,9 @@ class MultiWalkerEnv():
         # action is array of size 4
         action = action.reshape(4)
         self.walkers[agent_id].apply_action(action)
-        self.world.Step(1.0 / FPS, 6 * 30, 2 * 30)
-        self.frames = self.frames + 1
         if is_last:
+            self.world.Step(1.0 / FPS, 6 * 30, 2 * 30)
+            self.frames = self.frames + 1
             rewards, done, mod_obs = self.scroll_subroutine()
             self.last_obs = mod_obs
             global_reward = rewards.mean()


### PR DESCRIPTION
The environment stepping in multiwalker happens in a suboptimal way currently. In particular, the effective framerate at which players can control the walkers is greatly reduced compared to the original. Given the high quality implementation of the Box2d physics engine, it is best for all agents to step at once. 