### PR TITLE
fixed bug that always returns first agent's observation

### DIFF
--- a/pettingzoo/sisl/pursuit/pursuit_base.py
+++ b/pettingzoo/sisl/pursuit/pursuit_base.py
@@ -351,8 +351,9 @@ class Pursuit():
         return obs
 
     def collect_obs(self, agent_layer, i):
-        for i in range(self.n_agents()):
-            return self.collect_obs_by_idx(agent_layer, i)
+        for j in range(self.n_agents()):
+            if i == j:
+                return self.collect_obs_by_idx(agent_layer, i)
         assert False, "bad index"
 
     def collect_obs_by_idx(self, agent_layer, agent_idx):


### PR DESCRIPTION
I noticed that I was getting the same agent's observations for each agent, and I think the bug is in the couple lines I changed. I tried to hold to the intent of the function and change as little as possible. If this does not reflect the intent, or is not a bug, please let me know. 