### PR TITLE
fixed pistonball ezpickle issue and tests to catch said issue

### DIFF
--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -26,7 +26,6 @@ jobs:
       run: |
         export AUDIODEV=null
         sudo apt-get install swig
-        sudo apt install freeglut3-dev
         sudo apt-get install unrar
         pip install -r requirements.txt
         pip install AutoROM

--- a/pettingzoo/butterfly/pistonball/pistonball.py
+++ b/pettingzoo/butterfly/pistonball/pistonball.py
@@ -42,7 +42,7 @@ class raw_env(AECEnv, EzPickle):
     metadata = {'render.modes': ['human', "rgb_array"]}
 
     def __init__(self, n_pistons=20, local_ratio=0.2, time_penalty=-0.1, continuous=False, random_drop=True, random_rotate=True, ball_mass=0.75, ball_friction=0.3, ball_elasticity=1.5, max_cycles=900):
-        EzPickle.__init__(self, local_ratio, time_penalty, continuous, random_drop, random_rotate, ball_mass, ball_friction, ball_elasticity, max_cycles)
+        EzPickle.__init__(self, n_pistons, local_ratio, time_penalty, continuous, random_drop, random_rotate, ball_mass, ball_friction, ball_elasticity, max_cycles)
         self.n_pistons = n_pistons
         self.piston_head_height = 11
         self.piston_width = 40

--- a/pettingzoo/test/pytest_runner.py
+++ b/pettingzoo/test/pytest_runner.py
@@ -10,8 +10,6 @@ from .max_cycles_test import max_cycles_test
 
 @pytest.mark.parametrize(("name", "env_module"), list(all_environments.items()))
 def test_module(name, env_module):
-    if "classic" not in name:
-        return
     _env = env_module.env()
     api_test(_env)
     if "classic/" not in name:
@@ -19,4 +17,8 @@ def test_module(name, env_module):
 
     if "prospector" not in name:
         seed_test(env_module.env, 50)
+
     max_cycles_test(env_module, name)
+
+    recreated_env = pickle.loads(pickle.dumps(_env))
+    api_test(recreated_env)


### PR DESCRIPTION
Supersuit's vector env wrappers which depend on the ezpickle hack failed with an error due to a failure to update the ezpickle constructor in the latest pistonball update. 

Can reproduce with 

```
from pettingzoo.butterfly import pistonball_v3
import pickle
env = pistonball_v3.env()
env_dup = pickle.loads(pickle.dumps(env))
```

Also fixes test to catch above problem.

Does not bump version because this is fixing a very deterministic crashing issue. 