### PR TITLE
Suppress alsa errors on Linux

### DIFF
--- a/pettingzoo/__init__.py
+++ b/pettingzoo/__init__.py
@@ -1,4 +1,14 @@
 from pettingzoo.utils.env import AECEnv
 import pettingzoo.utils
+import sys
+
+# Initializing pygame initializes audio connections through SDL. SDL uses alsa by default on all Linux systems
+# SDL connecting to alsa frequently create these giant lists of warnings every time you import an environment using pygame
+# DSP is far more benign (and should probably be the default in SDL anyways)
+
+if sys.platform.startswith('linux'):
+    import os
+    os.environ['SDL_AUDIODRIVER'] = 'dsp'
+
 
 __version__ = "1.5.1"


### PR DESCRIPTION
So it turns out that issue #272 was our fault, sort of. Initializing pygame initializes an audio connect through SDL, which defaults to alsa on linux. Doing this is prone to absolutely insane error messages. This should fix that.