### PR TITLE
removed assertion error

### DIFF
--- a/pettingzoo/utils/wrappers.py
+++ b/pettingzoo/utils/wrappers.py
@@ -205,7 +205,7 @@ class OrderEnforcingWrapper(BaseWrapper):
         if value == "agent_order":
             raise AttributeError("agent_order has been removed from the API. Please consider using agent_iter instead.")
         elif value in {"rewards", "dones", "infos", "agent_selection", "num_agents", "agents"}:
-            raise AssertionError("{} cannot be accessed before reset".format(value))
+            raise AttributeError("{} cannot be accessed before reset".format(value))
         else:
             raise AttributeError("'{}' object has no attribute '{}'".format(type(self).__name__, value))
 


### PR DESCRIPTION
So this reverts a small change from #309 that changed the AttributeError to an AssertionError (this change happened after the last release, so no need for a new release). 

I realized that 

1. Making it an AttributeError is the only way to make catching the error sensible (because it is the naturally generated error type for this issue)
2. We do catch the error in BaseWrapper
3. Failing to catch the error results in important things like SuperSuit breaking. 