### PR TITLE
Fix crash caused by modulo zero - when all agents die, black death

### DIFF
--- a/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
+++ b/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
@@ -483,8 +483,8 @@ class raw_env(AECEnv, EzPickle):
             self.kill_list = []
 
             self._agent_selector.reinit(_live_agents)
-
-        self.agent_selection = self._agent_selector.next()
+        if len(self._agent_selector.agent_order):
+            self.agent_selection = self._agent_selector.next()
         self._cumulative_rewards[agent] = 0
         self._accumulate_rewards()
         self._dones_step_first()


### PR DESCRIPTION
Added an if statement checking if the agents_order of the agent selector is empty before calling next on the agent_selector.

I came across this bug, which caused division (modulo) by zero.

This happens when using parallel env + black death wrapper combined.

Specifically, it happens when the last agent is killed by a zombie, as far as I can tell.

This extra line prevents the run to crash.