### PR TITLE
fixed pistonball bug caused by pymunk

### DIFF
--- a/pettingzoo/butterfly/pistonball/pistonball.py
+++ b/pettingzoo/butterfly/pistonball/pistonball.py
@@ -195,7 +195,7 @@ class raw_env(AECEnv, EzPickle):
         segment = pymunk.Segment(piston, (0, 0), (self.piston_width - (2 * self.piston_radius), 0), self.piston_radius)
         segment.friction = .64
         segment.color = pygame.color.THECOLORS["blue"]
-        space.add(segment)
+        space.add(piston, segment)
         return piston
 
     def move_piston(self, piston, v):


### PR DESCRIPTION
When using pistonball.parallel_env()

I came across the following error:

Aborting due to Chipmunk error: The shape's body must be added to the space before the shape.
	Failed condition: shape->body->space == space
	Source:Chipmunk2D\src\cpSpace.c:423

I fixed this bug by adding the body (i.e. piston) before adding the shape (segment) to the space.

Hope this helps.