### PR TITLE
Fix the default max_cycles according to MPE documentation.

### DIFF
--- a/pettingzoo/mpe/simple_adversary_v2.py
+++ b/pettingzoo/mpe/simple_adversary_v2.py
@@ -4,7 +4,7 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 
 class raw_env(SimpleEnv):
-    def __init__(self, N=2, max_cycles=25):
+    def __init__(self, N=2, max_cycles=100):
         scenario = Scenario()
         world = scenario.make_world(N)
         super().__init__(scenario, world, max_cycles)

--- a/pettingzoo/mpe/simple_crypto_v2.py
+++ b/pettingzoo/mpe/simple_crypto_v2.py
@@ -4,7 +4,7 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 
 class raw_env(SimpleEnv):
-    def __init__(self, max_cycles=25):
+    def __init__(self, max_cycles=100):
         scenario = Scenario()
         world = scenario.make_world()
         super().__init__(scenario, world, max_cycles)

--- a/pettingzoo/mpe/simple_push_v2.py
+++ b/pettingzoo/mpe/simple_push_v2.py
@@ -4,7 +4,7 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 
 class raw_env(SimpleEnv):
-    def __init__(self, max_cycles=25):
+    def __init__(self, max_cycles=100):
         scenario = Scenario()
         world = scenario.make_world()
         super().__init__(scenario, world, max_cycles)

--- a/pettingzoo/mpe/simple_reference_v2.py
+++ b/pettingzoo/mpe/simple_reference_v2.py
@@ -4,7 +4,7 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 
 class raw_env(SimpleEnv):
-    def __init__(self, local_ratio=0.5, max_cycles=25):
+    def __init__(self, local_ratio=0.5, max_cycles=100):
         assert 0. <= local_ratio <= 1., "local_ratio is a proportion. Must be between 0 and 1."
         scenario = Scenario()
         world = scenario.make_world()

--- a/pettingzoo/mpe/simple_speaker_listener_v3.py
+++ b/pettingzoo/mpe/simple_speaker_listener_v3.py
@@ -4,7 +4,7 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 
 class raw_env(SimpleEnv):
-    def __init__(self, max_cycles=25):
+    def __init__(self, max_cycles=100):
         scenario = Scenario()
         world = scenario.make_world()
         super().__init__(scenario, world, max_cycles)

--- a/pettingzoo/mpe/simple_spread_v2.py
+++ b/pettingzoo/mpe/simple_spread_v2.py
@@ -4,7 +4,7 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 
 class raw_env(SimpleEnv):
-    def __init__(self, N=3, local_ratio=0.5, max_cycles=25):
+    def __init__(self, N=3, local_ratio=0.5, max_cycles=100):
         assert 0. <= local_ratio <= 1., "local_ratio is a proportion. Must be between 0 and 1."
         scenario = Scenario()
         world = scenario.make_world(N)

--- a/pettingzoo/mpe/simple_tag_v2.py
+++ b/pettingzoo/mpe/simple_tag_v2.py
@@ -4,7 +4,7 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 
 class raw_env(SimpleEnv):
-    def __init__(self, num_good=1, num_adversaries=3, num_obstacles=2, max_cycles=25):
+    def __init__(self, num_good=1, num_adversaries=3, num_obstacles=2, max_cycles=100):
         scenario = Scenario()
         world = scenario.make_world(num_good, num_adversaries, num_obstacles)
         super().__init__(scenario, world, max_cycles)

--- a/pettingzoo/mpe/simple_v2.py
+++ b/pettingzoo/mpe/simple_v2.py
@@ -4,7 +4,7 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 
 class raw_env(SimpleEnv):
-    def __init__(self, max_cycles=25):
+    def __init__(self, max_cycles=100):
         scenario = Scenario()
         world = scenario.make_world()
         super().__init__(scenario, world, max_cycles)

--- a/pettingzoo/mpe/simple_world_comm_v2.py
+++ b/pettingzoo/mpe/simple_world_comm_v2.py
@@ -4,7 +4,7 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 
 class raw_env(SimpleEnv):
-    def __init__(self, num_good=2, num_adversaries=4, num_obstacles=1, num_food=2, max_cycles=25):
+    def __init__(self, num_good=2, num_adversaries=4, num_obstacles=1, num_food=2, max_cycles=100):
         scenario = Scenario()
         num_forests = 2  # crahes with any other number of forrests
         world = scenario.make_world(num_good, num_adversaries, num_obstacles, num_food, num_forests)


### PR DESCRIPTION
Documentation of MPE environments:
The game terminates after the number of cycles specified by the max_cycles environment argument is executed.
The default for all environments is **100 cycles**. Note that in the original OpenAI source code, the default value was 25, not 100.