### PR TITLE
removed close() warning

### DIFF
--- a/pettingzoo/utils/wrappers/order_enforcing.py
+++ b/pettingzoo/utils/wrappers/order_enforcing.py
@@ -42,16 +42,6 @@ class OrderEnforcingWrapper(BaseWrapper):
         self._has_rendered = True
         return super().render(mode)
 
-    def close(self):
-        super().close()
-        if not self._has_rendered:
-            EnvLogger.warn_close_unrendered_env()
-        if not self._has_reset:
-            EnvLogger.warn_close_before_reset()
-
-        self._has_rendered = False
-        self._has_reset = False
-
     def step(self, action):
         if not self._has_reset:
             EnvLogger.error_step_before_reset()


### PR DESCRIPTION
Addressing #341 

Given how ambiguous the close() method is in gym, I'm not sure it is appropriate to raise any warnings on its use. This PR removes them all.