### PR TITLE
fixed from parallel wrapper

### DIFF
--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -123,6 +123,7 @@ class from_parallel_wrapper(AECEnv):
 
     def step(self, action):
         if self.dones[self.agent_selection]:
+            del self._actions[self.agent_selection]
             return self._was_done_step(action)
         self._actions[self.agent_selection] = action
         if self._agent_selector.is_last():


### PR DESCRIPTION
@rodrigodelazcano I think this is the correct fix to your problem. The parallel agent API does not take in a done, it takes in a smaller dictionary when you don't want to step the agent.