### PR TITLE
added gym style clone state methods to atari

### DIFF
--- a/pettingzoo/atari/base_atari_env.py
+++ b/pettingzoo/atari/base_atari_env.py
@@ -198,3 +198,32 @@ class ParallelAtariEnv(ParallelEnv, EzPickle):
             import pygame
             pygame.quit()
             self._screen = None
+
+    def clone_state(self):
+        """Clone emulator state w/o system state. Restoring this state will
+        *not* give an identical environment. For complete cloning and restoring
+        of the full state, see `{clone,restore}_full_state()`."""
+        state_ref = self.ale.cloneState()
+        state = self.ale.encodeState(state_ref)
+        self.ale.deleteState(state_ref)
+        return state
+
+    def restore_state(self, state):
+        """Restore emulator state w/o system state."""
+        state_ref = self.ale.decodeState(state)
+        self.ale.restoreState(state_ref)
+        self.ale.deleteState(state_ref)
+
+    def clone_full_state(self):
+        """Clone emulator state w/ system state including pseudorandomness.
+        Restoring this state will give an identical environment."""
+        state_ref = self.ale.cloneSystemState()
+        state = self.ale.encodeState(state_ref)
+        self.ale.deleteState(state_ref)
+        return state
+
+    def restore_full_state(self, state):
+        """Restore emulator state w/ system state including pseudorandomness."""
+        state_ref = self.ale.decodeState(state)
+        self.ale.restoreSystemState(state_ref)
+        self.ale.deleteState(state_ref)


### PR DESCRIPTION
Addresses #345 by adding the clone_state, restore_state methods from gym.

Combined with the `.unwrapped` attribute in #347 this should allow easy saving and loading of atari states. 