### PR TITLE
added seed test argument

### DIFF
--- a/docs/dev_docs.md
+++ b/docs/dev_docs.md
@@ -458,10 +458,17 @@ The seed test takes in a function that creates a pettingzoo environment. For exa
 from pettingzoo.test import seed_test
 from pettingzoo.butterfly import pistonball_v4
 env_fn = pistonball_v4.env
-seed_test(env_fn, num_cycles=10)
+seed_test(env_fn, num_cycles=10, test_kept_state=True)
 ```
 
-The optional argument, `num_cycles`, indicates how long the environment will be run to check for determinism. Some environments only fail the test long after initialization.
+Internally, there are two separate tests.
+
+1. Do two separate environments give the same result after the environment is seeded?
+2. Does a single environment give the same result after seed() then reset() is called?
+
+The first optional argument, `num_cycles`, indicates how long the environment will be run to check for determinism. Some environments only fail the test long after initialization.
+
+The second optional argument, `test_kept_state` allows the user to disable the second test. Some physics based environments fail this test due to barely detectable differences due to caches, etc, which are not important enough to matter.
 
 ### Max Cycles Test
 

--- a/pettingzoo/test/pytest_runner.py
+++ b/pettingzoo/test/pytest_runner.py
@@ -17,8 +17,8 @@ def test_module(name, env_module):
     if "classic/" not in name:
         parallel_api_test(env_module.parallel_env())
 
-    if "prospector" not in name:
-        seed_test(env_module.env, 50)
+    test_kept_state = "prospector" not in name
+    seed_test(env_module.env, 50, test_kept_state)
 
     if "classic/" not in name:
         max_cycles_test(env_module)

--- a/pettingzoo/test/seed_test.py
+++ b/pettingzoo/test/seed_test.py
@@ -86,9 +86,10 @@ def test_environment_reset_deterministic(env1, num_cycles):
     assert hash1 == hash2, "environments kept state after seed(42) and reset()"
 
 
-def seed_test(env_constructor, num_cycles=10):
+def seed_test(env_constructor, num_cycles=10, test_kept_state=True):
     env1 = env_constructor()
-    test_environment_reset_deterministic(env1, num_cycles)
+    if test_kept_state:
+        test_environment_reset_deterministic(env1, num_cycles)
     env2 = env_constructor()
     base_seed = 42
     env1.seed(base_seed)


### PR DESCRIPTION
Adds an argument to the seed test to allow the user to disable part of the seed test. Improved documentation of the seed test.

This PR is to make the SMAC tests pass reasonably.

Also makes the seed test run on prospector again. 