### PR TITLE
refactored render test, allowed for non-standard render modes

### DIFF
--- a/pettingzoo/test/__init__.py
+++ b/pettingzoo/test/__init__.py
@@ -1,5 +1,5 @@
 from .api_test import api_test
-from .render_test import render_test
+from .render_test import render_test, collect_render_results
 from .seed_test import seed_test
 from .save_obs_test import test_save_obs
 from .max_cycles_test import max_cycles_test

--- a/pettingzoo/test/render_test.py
+++ b/pettingzoo/test/render_test.py
@@ -2,30 +2,37 @@ import random
 import numpy as np
 
 
+def collect_render_results(env, mode):
+    results = []
+
+    env.reset()
+    for i in range(5):
+        if i > 0:
+            for agent in env.agent_iter(env.num_agents // 2 + 1):
+                obs, reward, done, info = env.last()
+                if done:
+                    action = None
+                elif isinstance(obs, dict) and 'action_mask' in obs:
+                    action = random.choice(np.flatnonzero(obs['action_mask']))
+                else:
+                    action = env.action_spaces[agent].sample()
+                env.step(action)
+        render_result = env.render(mode=mode)
+        results.append(render_result)
+
+    return results
+
+
 def render_test(env):
     render_modes = env.metadata.get('render.modes')
     assert render_modes is not None, "Environment's that support rendering must define render modes in metadata"
-    env.reset()
     for mode in render_modes:
-        assert (mode in {"human", "ansi", "rgb_array"})
-        env.reset()
-        for i in range(5):
-            if i > 0:
-                for agent in env.agent_iter(env.num_agents // 2 + 1):
-                    obs, reward, done, info = env.last()
-                    if done:
-                        action = None
-                    elif isinstance(obs, dict) and 'action_mask' in obs:
-                        action = random.choice(np.flatnonzero(obs['action_mask']))
-                    else:
-                        action = env.action_spaces[agent].sample()
-                    env.step(action)
-            res = env.render(mode=mode)
+        render_results = collect_render_results(env, mode)
+        for res in render_results:
             if mode == 'rgb_array':
                 assert isinstance(res, np.ndarray) and len(res.shape) == 3 and res.shape[2] == 3 and res.dtype == np.uint8, f"rgb_array mode must return a valid image array, is {res}"
             if mode == 'ansi':
                 assert isinstance(res, str)  # and len(res.shape) == 3 and res.shape[2] == 3 and res.dtype == np.uint8, "rgb_array mode must have shit in it"
             if mode == "human":
                 assert res is None
-        env.reset()
     env.close()


### PR DESCRIPTION
* Render test allows for non-standard render modes
* Refactored render test into two seperate functions, `render_test`, which does the same thing before, and a useful helper function `collect_render_results`, which gets the return values of render(). These results could be checked by an external test (for example, for a non-standard mode). 