### PR TITLE
minor doc typo combined arms env

### DIFF
--- a/docs/magent/combined_arms.md
+++ b/docs/magent/combined_arms.md
@@ -15,7 +15,7 @@ agent-labels: "agents= [redmelee_[0-44], redranged_[0-35], bluemelee_[0-44], blu
 
 
 
-A large-scale team battle. Here there are two types of agents on each team, ranged units which can attack father and move faster but have less HP, and melee units which can only attack close units and move more slowly but have more HP. Unlike battle and battlefield, agents can attack units on their own team (they just are not rewarded for doing so). Agents slowly regain HP over time, so it is best to kill an opposing agent quickly. Specifically, agents have 10 HP, are damaged 2 HP by each attack, and recover 0.1 HP every turn.
+A large-scale team battle. Here there are two types of agents on each team, ranged units which can attack farther and move faster but have less HP, and melee units which can only attack close units and move more slowly but have more HP. Unlike battle and battlefield, agents can attack units on their own team (they just are not rewarded for doing so). Agents slowly regain HP over time, so it is best to kill an opposing agent quickly. Specifically, agents have 10 HP, are damaged 2 HP by each attack, and recover 0.1 HP every turn.
 
 #### Action Space
 


### PR DESCRIPTION
I think the intention was to write "farther" instead of "father"