### PR TITLE
fix agent binary_id

### DIFF
--- a/pettingzoo/magent/adversarial_pursuit_v2.py
+++ b/pettingzoo/magent/adversarial_pursuit_v2.py
@@ -37,6 +37,7 @@ def get_config(map_size, minimap_mode, tag_penalty):
 
     cfg.set({"map_width": map_size, "map_height": map_size})
     cfg.set({"minimap_mode": minimap_mode})
+    cfg.set({"embedding_size": 10})
 
     options = {
         'width': 2, 'length': 2, 'hp': 1, 'speed': 1,


### PR DESCRIPTION
In the magent adversarial pursuit environment the binary_id agent feature was missing. The documentation for this environment states that this observation is implemented. Also, it is good to add it so that the observations are consistent between the environments