### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -46,15 +46,15 @@ PettingZoo models games as *Agent Environment Cycle* (AEC) games, and thus can s
 
 `num_agents`: The length of the agents list.
 
-`possible_agents`: A list of all possible_agents the environment could generate. Equivalent to the list of agents in the observation and action spaces. This cannot be changed through play or reseting.
+`possible_agents`: A list of all possible_agents the environment could generate. Equivalent to the list of agents in the observation and action spaces. This cannot be changed through play or resetting.
 
 `max_num_agents`: The length of the possible_agents list.
 
 `agent_selection` an attribute of the environment corresponding to the currently selected agent that an action can be taken for.
 
-`observation_spaces`: A dict of the observation spaces of every agent, keyed by name. This cannot be changed through play or reseting.
+`observation_spaces`: A dict of the observation spaces of every agent, keyed by name. This cannot be changed through play or resetting.
 
-`action_spaces`: A dict of the action spaces of every agent, keyed by name. This cannot be changed through play or reseting.
+`action_spaces`: A dict of the action spaces of every agent, keyed by name. This cannot be changed through play or resetting.
 
 `state_space`: The space of a global observation of the environment. Not all environments will support this feature.
 

--- a/docs/atari.md
+++ b/docs/atari.md
@@ -41,7 +41,7 @@ env = supersuit.max_observation_v0(env, 2)
 env = supersuit.sticky_actions_v0(env, repeat_action_probability=0.25)
 
 # skip frames for faster processing and less control
-# to be compatable with gym, use frame_skip(env, (2,5))
+# to be compatible with gym, use frame_skip(env, (2,5))
 env = supersuit.frame_skip_v0(env, 4)
 
 # downscale observation for faster processing

--- a/docs/atari/boxing.md
+++ b/docs/atari/boxing.md
@@ -22,7 +22,7 @@ appropriate responses to your opponent are key.
 
 The players have two minutes (around 1200 steps) to duke it
 out in the ring. Each step, they can move and punch.
-Sucessful punches score points,
+Successful punches score points,
 1 point for a long jab, 2 for a close power punch,
 and 100 points for a KO (which also will end the game).
 Whenever you score a number of points, you are rewarded by

--- a/docs/atari/double_dunk.md
+++ b/docs/atari/double_dunk.md
@@ -24,7 +24,7 @@ then the player is rewarded -1, and the timer resets. This prevents one player f
 
 Once play begins, each team has two players. You only control
 one at a time, and and which one you control depends on the selected play.
-Scoring should be familar to basketball fans (2-3 points per successful shot).
+Scoring should be familiar to basketball fans (2-3 points per successful shot).
 
 [Official double dunk manual](https://atariage.com/manual_html_page.php?SoftwareLabelID=153)
 

--- a/docs/butterfly/prospector.md
+++ b/docs/butterfly/prospector.md
@@ -56,7 +56,7 @@ and a banker depositing the gold into a bank. There is
 an individual reward, a group reward (for agents of the same type), and
 an other-group reward (for agents of the other type).
 
-By default, if a prospector retrives a nugget from the water, then
+By default, if a prospector retrieves a nugget from the water, then
 that prospector receives a reward of
 0.8, other
 prospectors will

--- a/docs/classic/backgammon.md
+++ b/docs/classic/backgammon.md
@@ -67,7 +67,7 @@ Encoding of the current player:
 
 #### Legal Actions Mask
 
-The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whos turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
+The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whose turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
 
 ### Action Space
 The action space for this environment is Discrete(26^2 * 2 + 1).

--- a/docs/classic/checkers.md
+++ b/docs/classic/checkers.md
@@ -39,7 +39,7 @@ Note that there are only 32 occupiable spaces (the dark colored spaced on a real
 
 #### Legal Actions Mask
 
-The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whos turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
+The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whose turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
 
 #### Action Space
 

--- a/docs/classic/chess.md
+++ b/docs/classic/chess.md
@@ -42,7 +42,7 @@ Unlike AlphaZero, the observation space does not stack the observations previous
 
 #### Legal Actions Mask
 
-The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whos turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
+The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whose turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
 
 ### Action Space
 

--- a/docs/classic/connect_four.md
+++ b/docs/classic/connect_four.md
@@ -27,7 +27,7 @@ The main observation space is 2 planes of a 6x7 grid. Each plane represents a sp
 
 #### Legal Actions Mask
 
-The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whos turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
+The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whose turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
 
 
 ### Action Space

--- a/docs/classic/dou_dizhu.md
+++ b/docs/classic/dou_dizhu.md
@@ -91,7 +91,7 @@ The obsesrvation space of the landlord and the two peasants have different dimen
 
 #### Legal Actions Mask
 
-The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whos turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
+The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whose turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
 
 
 ### Action Space

--- a/docs/classic/gin_rummy.md
+++ b/docs/classic/gin_rummy.md
@@ -58,7 +58,7 @@ The main observation space is 5x52 with the rows representing different planes a
 
 #### Legal Actions Mask
 
-The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whos turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
+The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whose turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
 
 ### Action Space
 

--- a/docs/classic/go.md
+++ b/docs/classic/go.md
@@ -62,7 +62,7 @@ While rendering, the board coordinate system is [GTP](http://www.lysator.liu.se/
 
 #### Legal Actions Mask
 
-The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whos turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
+The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whose turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
 
 
 ### Action Space

--- a/docs/classic/hanabi.md
+++ b/docs/classic/hanabi.md
@@ -75,19 +75,19 @@ As players reveal info about their cards, the information revealed per card is a
 | 283-307 | Vector Representing Card that was last played   |  [0, 1]  |
 | 308-342 | Revealed Info of This Player's 0th Card         |  [0, 1]  |
 | 343-377 | Revealed Info of This Player's 1st Card         |  [0, 1]  |
-| 378-412 | Revealed Info of This Player's 2st Card         |  [0, 1]  |
-| 413-447 | Revealed Info of This Player's 3st Card         |  [0, 1]  |
-| 445-482 | Revealed Info of This Player's 4st Card         |  [0, 1]  |
+| 378-412 | Revealed Info of This Player's 2nd Card         |  [0, 1]  |
+| 413-447 | Revealed Info of This Player's 3rd Card         |  [0, 1]  |
+| 445-482 | Revealed Info of This Player's 4th Card         |  [0, 1]  |
 | 483-517 | Revealed Info of Other Player's 0th Card        |  [0, 1]  |
 | 518-552 | Revealed Info of Other Player's 1st Card        |  [0, 1]  |
-| 553-587 | Revealed Info of Other Player's 2st Card        |  [0, 1]  |
-| 588-622 | Revealed Info of Other Player's 3st Card        |  [0, 1]  |
-| 663-657 | Revealed Info of Other Player's 4st Card        |  [0, 1]  |
+| 553-587 | Revealed Info of Other Player's 2nd Card        |  [0, 1]  |
+| 588-622 | Revealed Info of Other Player's 3rd Card        |  [0, 1]  |
+| 663-657 | Revealed Info of Other Player's 4th Card        |  [0, 1]  |
 
 
 #### Legal Actions Mask
 
-The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whos turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
+The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whose turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
 
 ### Action Space
 

--- a/docs/classic/leduc_holdem.md
+++ b/docs/classic/leduc_holdem.md
@@ -44,7 +44,7 @@ As described by [RLCard](https://github.com/datamllab/rlcard/blob/master/docs/ga
 
 #### Legal Actions Mask
 
-The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whos turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
+The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whose turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
 
 ### Action Space
 

--- a/docs/classic/mahjong.md
+++ b/docs/classic/mahjong.md
@@ -60,7 +60,7 @@ The main observation space has a (6, 34, 4) shape with the first index represent
 
 #### Legal Actions Mask
 
-The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whos turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
+The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whose turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
 
 ### Action Space
 

--- a/docs/classic/texas_holdem.md
+++ b/docs/classic/texas_holdem.md
@@ -42,7 +42,7 @@ The main observation space is similar to Texas Hold'em. The first 52 entries rep
 
 #### Legal Actions Mask
 
-The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whos turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
+The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whose turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
 
 ### Action Space
 

--- a/docs/classic/texas_holdem_no_limit.md
+++ b/docs/classic/texas_holdem_no_limit.md
@@ -22,7 +22,7 @@ texas_holdem_no_limit_v5.env(num_players=2)
 `num_players`: Sets the number of players in the game. Minimum is 2.
 
 
-Texas Hold'em is a poker game involving 2 players and a regular 52 cards deck. At the beginning, both players get two cards. After betting, three community cards are shown and another round follows. At any time, a player could fold and the game will end. The winner will receive +1 as a reward and the loser will get -1. This is an implementation of the standard limitted version of Texas Hold'm, sometimes referred to as 'Limit Texas Hold'em'.
+Texas Hold'em is a poker game involving 2 players and a regular 52 cards deck. At the beginning, both players get two cards. After betting, three community cards are shown and another round follows. At any time, a player could fold and the game will end. The winner will receive +1 as a reward and the loser will get -1. This is an implementation of the standard limited version of Texas Hold'm, sometimes referred to as 'Limit Texas Hold'em'.
 
 Our implementation wraps [RLCard](http://rlcard.org/games.html#limit-texas-hold-em) and you can refer to its documentation for additional details. Please cite their work if you use this game in research.
 
@@ -46,7 +46,7 @@ The main observation space is a vector of 72 boolean integers. The first 52 entr
 
 #### Legal Actions Mask
 
-The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whos turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
+The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whose turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
 
 ### Action Space
 

--- a/docs/classic/tictactoe.md
+++ b/docs/classic/tictactoe.md
@@ -25,7 +25,7 @@ The main observation is 2 planes of the 3x3 board. For player_1, the first plane
 
 #### Legal Actions Mask
 
-The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whos turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
+The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whose turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
 
 ### Action Space
 

--- a/docs/classic/uno.md
+++ b/docs/classic/uno.md
@@ -67,7 +67,7 @@ The main observation space has a shape of (7, 4, 15). Planes 0-2 represent the c
 
 #### Legal Actions Mask
 
-The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whos turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
+The legal moves available to the current agent are found in the `action_mask` element of the dictionary observation. The `action_mask` is a binary vector where each index of the vector represents whether the action is legal or not. The `action_mask` will be all zeros for any agent except the one whose turn it is. Taking an illegal move ends the game with a reward of -1 for the illegally moving agent and a reward of 0 for all other agents.
 
 ### Action Space
 

--- a/docs/dev_docs.md
+++ b/docs/dev_docs.md
@@ -37,7 +37,7 @@ def env():
     '''
     The env function wraps the environment in 3 wrappers by default. These
     wrappers contain logic that is common to many pettingzoo environments.
-    We recomend you use at least the OrderEnforcingWrapper on your own environment
+    We recommend you use at least the OrderEnforcingWrapper on your own environment
     to provide sane error messages. You can find full documentation for these methods
     elsewhere in the developer documentation.
     '''
@@ -214,7 +214,7 @@ def env():
     '''
     The env function wraps the environment in 3 wrappers by default. These
     wrappers contain logic that is common to many pettingzoo environments.
-    We recomend you use at least the OrderEnforcingWrapper on your own environment
+    We recommend you use at least the OrderEnforcingWrapper on your own environment
     to provide sane error messages. You can find full documentation for these methods
     elsewhere in the developer documentation.
     '''

--- a/docs/mpe/simple.md
+++ b/docs/mpe/simple.md
@@ -15,7 +15,7 @@ agent-labels: "agents= [agent_0]"
 
 
 
-In this environment a single agent sees a landmark position and is rewarded based on how close it gets to the landmark (Euclidian distance). This is not a multiagent environment, and is primarily intended for debugging purposes.
+In this environment a single agent sees a landmark position and is rewarded based on how close it gets to the landmark (Euclidean distance). This is not a multiagent environment, and is primarily intended for debugging purposes.
 
 Observation space: `[self_vel, landmark_rel_position]`
 

--- a/docs/mpe/simple_adversary.md
+++ b/docs/mpe/simple_adversary.md
@@ -15,7 +15,7 @@ agent-labels: "agents= [adversary_0, agent_0,agent_1]"
 
 
 
-In this environment, there is 1 adversary (red), N good agents (green), N landmarks (default N=2). All agents observe the position of landmarks and other agents. One landmark is the ‘target landmark’ (colored green). Good agents are rewarded based on how close the closest one of them is to the target landmark, but negatively rewarded based on how close the adversary is to the target landmark. The adversary is rewarded based on distance to the target, but it doesn’t know which landmark is the target landmark. All rewards are unscaled Euclidian distance (see main MPE documentation for average distance). This means good agents have to learn to ‘split up’ and cover all landmarks to deceive the adversary.
+In this environment, there is 1 adversary (red), N good agents (green), N landmarks (default N=2). All agents observe the position of landmarks and other agents. One landmark is the ‘target landmark’ (colored green). Good agents are rewarded based on how close the closest one of them is to the target landmark, but negatively rewarded based on how close the adversary is to the target landmark. The adversary is rewarded based on distance to the target, but it doesn’t know which landmark is the target landmark. All rewards are unscaled Euclidean distance (see main MPE documentation for average distance). This means good agents have to learn to ‘split up’ and cover all landmarks to deceive the adversary.
 
 Agent observation space: `[self_pos, self_vel, goal_rel_position, landmark_rel_position, other_agent_rel_positions]`
 

--- a/docs/sisl.md
+++ b/docs/sisl.md
@@ -1,4 +1,4 @@
-## SISL Enviroments
+## SISL Environments
 
 {% include bigtable.html group="sisl/" avg_rew=1 %}
 

--- a/pettingzoo/atari/maze_craze_v2.py
+++ b/pettingzoo/atari/maze_craze_v2.py
@@ -14,7 +14,7 @@ def raw_env(game_version="robbers", visibilty_level=0, **kwargs):
     if game_version == "robbers" and visibilty_level == 0:
         warnings.warn("maze_craze has different versions of the game via the `game_version` argument, consider overriding.")
     assert game_version in avaliable_versions, f"`game_version` parameter must be one of {avaliable_versions.keys()}"
-    assert 0 <= visibilty_level < 4, "visibility level must be between 0 and 4, where 0 is 100% visiblity and 3 is 0% visibility"
+    assert 0 <= visibilty_level < 4, "visibility level must be between 0 and 4, where 0 is 100% visibility and 3 is 0% visibility"
     base_mode = (avaliable_versions[game_version] - 1) * 4
     mode = base_mode + visibilty_level
     return BaseAtariEnv(game="maze_craze", num_players=2, mode_num=mode, env_name=os.path.basename(__file__)[:-3], **kwargs)

--- a/pettingzoo/atari/pong_v2.py
+++ b/pettingzoo/atari/pong_v2.py
@@ -27,7 +27,7 @@ avaliable_4p_versions = {
 def raw_env(num_players=2, game_version="classic", **kwargs):
     assert num_players == 2 or num_players == 4, "pong only supports 2 or 4 players"
     versions = avaliable_2p_versions if num_players == 2 else avaliable_4p_versions
-    assert game_version in versions, f"pong version {game_version} not supported for number of players {num_players}. Avaliable options are {list(versions)}"
+    assert game_version in versions, f"pong version {game_version} not supported for number of players {num_players}. Available options are {list(versions)}"
     mode = versions[game_version]
     return BaseAtariEnv(game="pong", num_players=num_players, mode_num=mode, env_name=os.path.basename(__file__)[:-3], **kwargs)
 

--- a/pettingzoo/classic/chess/chess_env.py
+++ b/pettingzoo/classic/chess/chess_env.py
@@ -97,7 +97,7 @@ class raw_env(AECEnv):
 
         is_stale_or_checkmate = not any(next_legal_moves)
 
-        # claim draw is set to be true to allign with normal tournament rules
+        # claim draw is set to be true to align with normal tournament rules
         is_repetition = self.board.is_repetition(3)
         is_50_move_rule = self.board.can_claim_fifty_moves()
         is_claimable_draw = is_repetition or is_50_move_rule

--- a/pettingzoo/classic/chess/chess_utils.py
+++ b/pettingzoo/classic/chess/chess_utils.py
@@ -150,7 +150,7 @@ def make_move_mapping(uci_move):
 
 def legal_moves(orig_board):
     '''
-    action space is a 8x8x73 dimentional array
+    action space is a 8x8x73 dimensional array
     Each of the 8×8
     positions identifies the square from which to “pick up” a piece. The first 56 planes encode
     possible ‘queen moves’ for any piece: a number of squares [1..7] in which the piece will be
@@ -179,8 +179,8 @@ def legal_moves(orig_board):
 
 def get_observation(orig_board, player):
     '''
-    Observation is an 8x8x(P + L) dimentional array
-    P is going to be your peices positions + your opponents peices positions
+    Observation is an 8x8x(P + L) dimensional array
+    P is going to be your pieces positions + your opponents pieces positions
     L is going to be some metadata such as repetition count,,
     '''
     board = orig_board

--- a/pettingzoo/classic/hanabi/hanabi.py
+++ b/pettingzoo/classic/hanabi/hanabi.py
@@ -277,7 +277,7 @@ class raw_env(AECEnv, EzPickle):
             # Update internal state
             self._process_latest_observations(obs=all_observations, reward=reward, done=done)
 
-            # sets current reward for 0 to intialize reward accumulation
+            # sets current reward for 0 to initialize reward accumulation
             self._cumulative_rewards[agent_on_turn] = 0
             self._accumulate_rewards()
 

--- a/pettingzoo/mpe/_mpe_utils/core.py
+++ b/pettingzoo/mpe/_mpe_utils/core.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-class EntityState(object):  # physical/external base state of all entites
+class EntityState(object):  # physical/external base state of all entities
     def __init__(self):
         # physical position
         self.p_pos = None

--- a/pettingzoo/mpe/_mpe_utils/rendering.py
+++ b/pettingzoo/mpe/_mpe_utils/rendering.py
@@ -14,7 +14,7 @@ except ImportError:
 try:
     from pyglet.gl import glEnable, glHint, glLineWidth, glBlendFunc, glBegin, glPushMatrix, glTranslatef, glClearColor, glRotatef, glScalef, glPopMatrix, glColor4f, glLineStipple, glDisable, glVertex3f, glEnd, glVertex2f, gluOrtho2D
 except ImportError:
-    raise ImportError("""Error occured while running `from pyglet.gl import ...`
+    raise ImportError("""Error occurred while running `from pyglet.gl import ...`
             HINT: make sure you have OpenGL install. On Ubuntu, you can run 'apt-get install python-opengl'. If you're running on a server, you may need a virtual frame buffer; something like this should work: 'xvfb-run -s \"-screen 0 1400x900x24\" python <your_script.py>'""")
 
 from pyglet.gl import GL_BLEND, GL_LINE_SMOOTH, GL_LINE_SMOOTH_HINT, GL_NICEST, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_LINE_STIPPLE, GL_POINTS, GL_QUADS, GL_LINE_LOOP, GL_POLYGON, GL_TRIANGLES, GL_LINE_STRIP, GL_LINES

--- a/pettingzoo/sisl/pursuit/utils/discrete_agent.py
+++ b/pettingzoo/sisl/pursuit/utils/discrete_agent.py
@@ -12,7 +12,7 @@ class DiscreteAgent(Agent):
 
     # constructor
     def __init__(self, xs, ys, map_matrix, randomizer, obs_range=3, n_channels=3, seed=1, flatten=False):
-        # map_matrix is the may of the enviroment (-1 are buildings)
+        # map_matrix is the may of the environment (-1 are buildings)
         # n channels is the number of observation channels
 
         self.random_state = randomizer

--- a/pettingzoo/test/seed_test.py
+++ b/pettingzoo/test/seed_test.py
@@ -96,4 +96,4 @@ def seed_test(env_constructor, num_cycles=10, test_kept_state=True):
     env2.seed(base_seed)
 
     assert check_environment_deterministic(env1, env2, num_cycles), \
-        ("The environment gives different results on multiple runs when intialized with the same seed. This is usually a sign that you are using np.random or random modules directly, which uses a global random state.")
+        ("The environment gives different results on multiple runs when initialized with the same seed. This is usually a sign that you are using np.random or random modules directly, which uses a global random state.")

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -69,7 +69,7 @@ class to_parallel_wrapper(ParallelEnv):
         for agent in self.aec_env.agents:
             if agent != self.aec_env.agent_selection:
                 if self.aec_env.dones[agent]:
-                    raise AssertionError(f"expected agent {agent} got done agent {self.aec_env.agent_selection}. Parallel enviornment wrapper expects all agent termination (setting an agent's self.dones entry to True) to happen only at the end of a cycle.")
+                    raise AssertionError(f"expected agent {agent} got done agent {self.aec_env.agent_selection}. Parallel environment wrapper expects all agent termination (setting an agent's self.dones entry to True) to happen only at the end of a cycle.")
                 else:
                     raise AssertionError(f"expected agent {agent} got agent {self.aec_env.agent_selection}, Parallel environment wrapper expects agents to step in a cycle.")
             obs, rew, done, info = self.aec_env.last()

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -123,7 +123,7 @@ class AECEnv:
         2. Loads next agent into .agent_selection: if another agent is done, loads that one, otherwise load next live agent
         3. Clear the rewards dict
 
-        Highly recomended to use at the beginning of step as follows:
+        Highly recommended to use at the beginning of step as follows:
 
         def step(self, action):
             if self.dones[self.agent_selection]:
@@ -136,7 +136,7 @@ class AECEnv:
 
         # removes done agent
         agent = self.agent_selection
-        assert self.dones[agent], "an agent that was not done as attemted to be removed"
+        assert self.dones[agent], "an agent that was not done as attempted to be removed"
         del self.dones[agent]
         del self.rewards[agent]
         del self._cumulative_rewards[agent]


### PR DESCRIPTION
[`codespell --ignore-words-list="magent" --skip="*.css,*.js,*.map,*.scss,*.svg"`](https://pypi.org/project/codespell/)

https://www.grammarly.com/blog/whos-whose/