### PR TITLE
Migrate to new AutoROM release

### DIFF
--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -25,7 +25,8 @@ jobs:
       run: |
         export AUDIODEV=null
         sudo apt-get install swig unrar
-        pip install AutoROM bandit codespell flake8 pytest -r requirements.txt
+        pip install bandit codespell flake8 pytest -r requirements.txt
+        pip install git+https://github.com/JesseFarebro/AutoROM
         AutoROM -v
     - name: Full Python tests
       run: |

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -20,7 +20,8 @@ jobs:
       run: |
         export AUDIODEV=null
         brew install swig rar
-        pip install AutoROM pytest -r requirements.txt
+        pip install pytest -r requirements.txt
+        pip install git+https://github.com/JesseFarebro/AutoROM
         AutoROM -v
     - name: Full Python tests
       run: |


### PR DESCRIPTION
AutoROM now installs without the game name as the path. Furthermore, when installing to a user-specified directory `ROM/` isn't automatically appended. 